### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/libnx"]
 	path = libs/libnx
-	url = git@github.com:switchbrew/libnx.git
+	url = https://github.com/switchbrew/libnx.git


### PR DESCRIPTION
Updated to use https, don't have access via ssh. 

```
Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:switchbrew/libnx.git' into submodule path '/c/nx-sd/components/EdiZon/libs/libnx' failed
Failed to clone 'libs/libnx'. Retry scheduled
Cloning into '/c/nx-sd/components/EdiZon/libs/libnx'...
Permission denied (publickey).
fatal: Could not read from remote repository.
```